### PR TITLE
Reusable passage instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "passage-id"
 description = "Server SDK for passage.id authentication"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 repository = "https://github.com/robyoder/passage-rust/"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ fn main() {
     // Your app id from https://console.passage.id/settings
     let app_id = "...";
 
-    // Your app's public jwk key from https://auth.passage.id/v1/apps/{app_id}/.well-known/jwks.json.
+    // Create an api key for your app at https://console.passage.id/settings/apikeys
+    let api_key = "...";
+
+    // Download your app's public jwk key from https://auth.passage.id/v1/apps/{app_id}/.well-known/jwks.json. Note this is a single key, not an array.
     let pub_key = r#"{
         "alg": "RS256",
         "kty": "RSA",
@@ -32,10 +35,12 @@ fn main() {
         "kid": "..."
       }"#;
 
+    // The Passage struct can be created once, stored/cached, and reused across multiple requests.
+    let passage = Passage::new(String::from(app_id), String::from(api_key), String::from(pub_key));
+
     // If you are using an Element, the Passage JWT will be sent to your application via a cookie with the key `psg_auth_token`
     let psg_auth_token = "...";
-    let passage = Passage::new(String::from(app_id));
-    let result = passage.authenticate_token(psg_auth_token, pub_key);
+    let result = passage.authenticate_token(psg_auth_token);
 
     match result {
         Ok(passage_user_id) => println!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,15 @@
 //!
 //! This crate provides a library for working with [Passage](https://passage.id), a modern passwordless authentication experience based on passkeys and magic links. This library currently implements a very small subset of the available Passage API endpoints.
 //!
-//! See Passage [Authentication API](https://docs.passage.id/api-docs/authentication-api) and [Management API](https://docs.passage.id/api-docs/management-api)  for all the possible endpoints that could be added to this crate in the future.
+//! See Passage [Authentication API](https://docs.passage.id/api-docs/authentication-api) and [Management API](https://docs.passage.id/api-docs/management-api) for all the possible endpoints that could be added to this crate in the future.
 //!
 //! ## Usage
 //!
-//! This crate is on [crates.io](https://crates.io/crates/passage-id) and can be used by adding `passage-id` to your dependencies in your project's Cargo.toml.
+//! This crate is published on [crates.io](https://crates.io/crates/passage-id) and can be added with `cargo add passage-id` or by manually adding `passage` to your Cargo.toml dependencies.
 //!
 //! ```toml
 //! [dependencies]
-//! passage-id = "latest"
+//! passage-id = "0.1"
 //! ```
 //!
 use jsonwebkey as jwk;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,14 @@ use jsonwebkey as jwk;
 use jsonwebtoken as jwt;
 use serde::Deserialize;
 
-/// Passage is the main entry point you'll be working with. Create with [Passage::new].
+/// Passage is the main entry point you'll be working with. See [Passage::new] for details on where to find these values for your app.
 pub struct Passage {
     app_id: String,
+    #[allow(dead_code)]
+    api_key: String,
+    #[allow(dead_code)]
+    base_uri: String,
+    pub_jwk: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -44,18 +49,17 @@ pub enum AuthError {
 }
 
 impl Passage {
-    /// Creates a new [Passage] for interacting with the Passage API. Your `app_id` can be found in the [Passage console](https://console.passage.id).
-    pub fn new(app_id: String) -> Self {
-        Passage { app_id }
-    }
-
-    /// Verify the Passage authentication token. When successful, the resulting `String` is the authenticated Passage user ID. See [Validation Passage JWTs](https://docs.passage.id/backend/overview/other#validation-passage-jwts) for details.
+    /// Creates a new [Passage] for interacting with the Passage API.
     ///
     /// ```rust
-    /// // Your app id from https://console.passage.id/settings
+    /// use passage_id::Passage;
+    /// // Find your app id from https://console.passage.id/settings
     /// let app_id = "cHxJnV5eqc8aIrgQjgfIEsMl";
     ///
-    /// // Your app's public JWK from https://auth.passage.id/v1/apps/{app_id}/.well-known/jwks.json. You only want the key itself, not the array.
+    /// // Create an api key for your app at https://console.passage.id/settings/apikeys
+    /// let api_key = "P5H1fLoYIv.MxVnHArwp8xJ3q0FDoByoUiDJC0r5ABcqK6ozXyFmeacdNfySuaFLYN75YrS6JT1";
+    ///
+    /// // You can download the public jwk key for your app from https://auth.passage.id/v1/apps/{app_id}/.well-known/jwks.json. You only want the key itself, not the array.
     /// let pub_key = r#"{
     ///     "alg": "RS256",
     ///     "kty": "RSA",
@@ -65,11 +69,34 @@ impl Passage {
     ///     "kid": "..."
     ///   }"#;
     ///
-    /// // If you are using an Element, the Passage authentication JWT will be sent to your application via a cookie with the key `psg_auth_token`
+    /// let passage = Passage::new(String::from(app_id), String::from(api_key), String::from(pub_key));
+    /// ```
+    pub fn new(app_id: String, api_key: String, pub_jwk: String) -> Self {
+        Passage {
+            app_id,
+            api_key,
+            pub_jwk,
+            base_uri: String::from("https://api.passage.id/v1"),
+        }
+    }
+
+    /// Verify the Passage authentication token. When successful, the resulting `String` is the authenticated Passage user ID. See [Validation Passage JWTs](https://docs.passage.id/backend/overview/other#validation-passage-jwts) for details.
+    ///
+    /// ```rust
+    /// // See [Passage::new] for details on where to find these values
+    /// let app_id = "...";
+    /// let api_key = "...";
+    /// let pub_key = r#"{
+    ///     ...
+    /// }"#;
+    ///
+    /// use passage_id::Passage;
+    /// let passage = Passage::new(String::from(app_id), String::from(api_key), String::from(pub_key));
+    ///
+    /// // If you are using a standard [Passage Element](https://docs.passage.id/frontend/passage-element), the Passage authentication JWT will be sent to your application via a cookie with the key `psg_auth_token`
     /// let psg_auth_token = "...";
     ///
-    /// let passage = Passage::new(String::from(app_id));
-    /// let result = passage.authenticate_token(psg_auth_token, pub_key);
+    /// let result = passage.authenticate_token(psg_auth_token);
     ///
     /// match result {
     ///     Ok(passage_user_id) => println!(
@@ -81,8 +108,9 @@ impl Passage {
     ///     }
     /// }
     /// ```
-    pub fn authenticate_token(self, token: &str, pub_jwk: &str) -> Result<String, AuthError> {
-        let key = pub_jwk
+    pub fn authenticate_token(&self, token: &str) -> Result<String, AuthError> {
+        let key = self
+            .pub_jwk
             .parse::<jwk::JsonWebKey>()
             .map_err(|e| AuthError::PubKeyParsing(e.to_string()))?;
 
@@ -115,7 +143,11 @@ mod tests {
 
     #[test]
     fn init_passage() {
-        let passage = Passage::new(String::from("test"));
+        let passage = Passage::new(
+            String::from("test"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
         assert_eq!(passage.app_id, String::from("test"));
     }
 
@@ -133,8 +165,12 @@ mod tests {
     fn authenticate_good_token() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL2Zha2UiLCJleHAiOjIwMDAwMDAwMDB9.hPDcPU5Y84MTiQZ9uZ0aJqxzLEBQiD9F2xWeZINGIKbwehHudExV0MoqoLxHnpUcGIKPIaW0FjCDCZcJA2dGoLC6n-X8l7qUgMJBbbCIEtNhQNMe4AIlEpsmk3t83WNXSQVeh2fKBAJ1X_oad1RRNuQUgCam6MMJx8m3AozPBAXcGjS6D_pJ7N0oPEm5uNq_nSx0GqF0aEUMRiTqG1mY7f8mJtch7vJqxwWPlBZ32lrPmW0xswYLEx2sVZTnYFZqroZH31KePIpHoawrFTNuHQAsSCd1hI8Fj2gZ0ZfT8MFKftbx7_1Pum4KwK4eMv-W2urPsFH3-uU2G0wOaAi-yQ";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         assert_eq!(res, Ok("1234567890".to_owned()));
     }
@@ -143,8 +179,12 @@ mod tests {
     fn reject_bad_signature() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL2Zha2UiLCJleHAiOjIwMDAwMDAwMDB9.Pxj_GZChf9Cx70QAIpUpAPkJVFErhkxYrJCF3XHLyBdStWy17BrVVhnR2GBG5DCHOmI9jleUre-PUokETTu_nqAGhPB1fulouZUZwZPgJqS6kxQf4VSjumgTDUdmKyptAL2Yo1HOd-bqJrrSrLEST1iQgnWWuHmRcztQn89AxAGJkycAG6Pj8ot7qp3LC6xgOzlqL4mEqgLPNw-R_U_9Zr7Pqy8IbVWBxPz1rF9mPKPib1CLCQ_Jk_Ncmq_LyP70otyssmIEDvAovJn8tSsdIho9W4qGvSpHKeqZTxN0xJq-2KUXnORgrGOVu3cudc7SXmw31g3ZcRY09NUO0Q2uTg";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -156,8 +196,12 @@ mod tests {
     fn reject_bad_kid() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFgzIiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL2Zha2UiLCJleHAiOjIwMDAwMDAwMDB9.UzLMx80WPn8UG2RcWKxR9OSimouOI8Ag4bS5IHOzI0ueVG4qu55JvQGPEsKbevmEzVUchj1F-r2BgKK87TThQ4L112WgntNomV19kGUaGPPhkqrmMS5-bk3wAjhTCXgg84QeuMKlqN7PpF6MP1u98psWLfHHFXLl2Sy6aDsjtT8Hag8NmWn83sz2oNLqJfXmApZ3lFpwIT4o8B6ZTVF7USTNxHlt9vtA7OdYDF4V1ZPMRAf4xOStfUayOLoHwnv0YX3IR5NvVhuMo1Ej4p2S6_q8pjx-8-CM5gCFRNt0xSGG6LXdH971wTbvTDVfVeBEABmBul5KXVNOZ54YUkZcpQ";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::KidMismatch(_, _)) => assert!(true),
@@ -169,8 +213,12 @@ mod tests {
     fn reject_missing_sub() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJuYmYiOjE2NzU0NjE2ODgsImlzcyI6Imh0dHBzOi8vYXV0aC5wYXNzYWdlLmlkL3YxL2FwcHMvZmFrZSIsImV4cCI6MjAwMDAwMDAwMH0.orBGLQfdSKV1NLyJqXZapREZIT7BAb33vY1ovvM3lbHS9S7fNT_qZz-bQZZ_NkrL9nMB8mmX2A4PyHWfin1pHZOvhNKhcsVeIfZHBP9SYzUzXsWdqmSiPqd6VBAhQZs1OSwJz4K6JV4_igR40QImxRvg2AXcu3AiUdGU0nuuJ9Vtd7RwdXUx41cVpIyCiOsN4kPFpVaSYQ1-Qn9aowBea5j4h7EIhZaLAkTDJT3KuQxyxhJnO2-XubrQREwd8CilOIV1evrdaQkR4Xqw3FBcvjOiRW6zW0sIdANxk_jIqC2Vdp0feQKYvUFxea3xHAujz5TIi9q7sJzgJPBsjI1MzA";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -182,8 +230,12 @@ mod tests {
     fn reject_missing_nbf() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaXNzIjoiaHR0cHM6Ly9hdXRoLnBhc3NhZ2UuaWQvdjEvYXBwcy9mYWtlIiwiZXhwIjoyMDAwMDAwMDAwfQ.lZ2zTZmJsIcQE2XDV-N8sVFvK2AxN4GWW_fId6yc2uSJFtQc26HcB0ywGn7BjhB8OD4rX3WkA9XqyUl51fKCnVlE8hlk4VlfDyewKahJkPmoqNX7QwDzA9ORd-5FlZJ1_8nsMzH0jn8ydkKJORgxGKfj_xZD73mW9gz31bVbYddPmPcAmhuJCvI_4dlNVmIfEk-UUNmtIJEc89iwbcg_baEUJDXXztUfYhw4M3WC58ptI5GZk9JLIcq5PU59Sn495d14Xeek19PD93ypSwsLRAwXXU6OQgRbFZtYdrshcDpZ3339RfuO6xBlTBqet5BbVMm-f28Mlqw2x2UvuQ_h-g";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -195,8 +247,12 @@ mod tests {
     fn reject_future_nbf() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoyMDAwMDAwMDAwLCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL2Zha2UiLCJleHAiOjIwMDAwMDAwNjB9.HoPwswPk4euGoVyXZMlo2lwzUhHtXrzhyc5ZGy8QI0pStvkYB_fDyyPsL8u-TuHKdm5ezakQr1mvYdnJABpMi1X3qsUMYbU2Rs0Wk906YYnzMAmMANRkKAXw5uLTBjdWu_NG-KMYWom_N0rYGBGGAq5np8k1OHJWrZDJamCdqqcIY7n7hD4mwXMwzLoKRQQtojvtRijnzKGMThUfe7-0YrMPIi941P2Z86MSDXennU2cuoJXAMYndxfdNFXyt74DocTKXEfWR1gtdZqcUCG12TAhWxm_6qRjMcDTiO1gpXGjoommCMxgRU3Mm-XM734MHLMFWFma9Ldci8rbrmeypg";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -208,8 +264,12 @@ mod tests {
     fn reject_missing_iss() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJleHAiOjIwMDAwMDAwMDB9.T61Xje9mZYOxQSIjvbV30gWqjz8kfZhqVG_KnCxmb3iXuERoTkjZFVZYeuHSKrTHMkxfrhAc7CjgREiHF1fJM9UCDWkl0CMpzfxfg5MVTF-ZoZ3cVmPjd4oslq5Ggjx7coo1kl7OhCY7w9XdGWGu7zCfMYmCNE-LwQ3h1Kj9NkxHv3HtcgKk6fvSdpMJ8IcIuGR-SLgr7yuQs9IBnwXb7tCSjY_5Lg3vpTpgB7_M2485Yyfx6ZUgUgY6u-8E3a2mMGbRtk3G6C_SnH4HTvkn2QGNd9b5F6Llcs4aQpKuSe--GIJg4FNVTKJ0M_27ycSZYu-UMolVmUm4QUqZCmLZzQ";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -221,8 +281,12 @@ mod tests {
     fn reject_wrong_iss() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL3dyb25nIiwiZXhwIjoyMDAwMDAwMDAwfQ.DTLsHvjK7ewJ1aajQdddMtHH2rx5ripQzjubOzZExNmtGvaVHUAlaa9vO_gu4NgpGg8m11IotqfeZUqLxVSSJ_GBLFVXcvBp2hRILs8JyU2uRdgur_n6Re1GoQpsfPqNxAdjDnRLE9QaXDDk-ErG3xdM4tDW9x_UGnrnlPAhePhGEXDSYzSDe0RmXFKcS0AzkQMztwiEW3HWunxVmZhMniPVWfzAuFqO28VVzLIpMFDsBsseHUzFhBDyzshNGHmk1t4pgEUXafrqi_DR_ammxP5Wp8U-4syzgNZ1WvVs7hJeXgDHAV3xwMH083p8p1HqqLsz5Zfqw8A6yu8TkcEctw";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -234,8 +298,12 @@ mod tests {
     fn reject_missing_exp() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL2Zha2UifQ.BXvWfR2zFI-Tm72BAZgqQuykfzs4cOswlPP_H-8usiBAwpg6LExhWis9R8YJch5fcHAUfgbIMxZnwhylfESXrqs9QxAarn0M3NIGF8bI32nTNPrQpBUJCzdYh6OCaJ8G7lftY2LTDcGHq0v18ikILykoloN69wjys-eStrW2yr3_XIGSkHpbOjVSSru30XTRndT30rImytR8EBsWN0vsgyucy2X0-NCfsfa3Wl4vQUV5nxtO1ejpTmr0LvfHENEXyEoA2Q5Rr5PuLHF03kbLjlD81OPPETUZdPPKclyjlPozKraX6TnvUGVQq4XM00YlL5qoUZ4HBLIVusKi_d9kPw";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),
@@ -247,8 +315,12 @@ mod tests {
     fn reject_past_exp() {
         let jwt_str = "eyJraWQiOiJyNTB2S3VrSmw0b1ZhVDc4TzBFTElHUzR3OHluTVlfNGxSU0JxLXV2VFg0IiwiYWxnIjoiUlMyNTYiLCJ0eXAiOiJKV1QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmJmIjoxNjc1NDYxNjg4LCJpc3MiOiJodHRwczovL2F1dGgucGFzc2FnZS5pZC92MS9hcHBzL2Zha2UiLCJleHAiOjE2NzU0NjE4ODh9.YJlpsocdeIAaMATZDBz5EsdbOhtNDTDGr4_j7mEtWthU0JJdhWIoNxaX5Dep1C9yNf8hFFg0r3re6ImoQz4-vMkOGmObUxAP-7hlMEhfx8ww7Slj1vn_3ZEAHrp3JUS4jirQNak9-qvOr4Ndh0XsvzVAWca216hAo2PMXZwmaS8vBG8bpm5sVFevB6f-rW3OVEgafcmagRlFpgXLum6vcw18nsRV9qcvcQZDlW9x7Z7cJEW13e35qWz_urdOgB9EdD_feVuG1zlE_MbBgE6EtSNTumlqnB_Iae1KeM-nHJkeKkCbfvbd1WCc5lI3N8mv0M7m7nRBxQM6TFSbXqrI2g";
 
-        let passage = Passage::new(String::from("fake"));
-        let res = passage.authenticate_token(jwt_str, PUB_JWK);
+        let passage = Passage::new(
+            String::from("fake"),
+            String::from("fake_api_key"),
+            String::from(PUB_JWK),
+        );
+        let res = passage.authenticate_token(jwt_str);
 
         match res {
             Err(AuthError::TokenDecoding(_)) => assert!(true),


### PR DESCRIPTION
The original design planned for `Passage` to be used once and thrown away after performing `authenticate_token`. This resulted in the leanest possible implementation.

While attempting to add the `get_user` functionality from the Passage Management API I required that `Passage` contain an api key. I also found it helpful to be able to create `Passage` once and then store it in state so Rocket could reuse it across all requests. 

A discovery chat with @robyoder found that the original approach was not a requirement and so this MR changes the assumption on how `Passage` will be used. 

* Once `Passage` started being reused it made sense to include `pub_jwk` as well and remove it from the `passage.authenticate_token` method signature. 
* All tests were updated to reflect this change.
* Expanded `Passage` to include `api_key` and `base_uri` while I was here. It would have made a bit more sense to add `api_key` in a future future MR but I wanted to update all the tests once and only once. 
* Doc tests now pass as well

If we find a need for the original approach of super-quick token authentication we can provide a standalone `authenticate_token` function. 

# All tests pass with flying colours ✅🚀

```
❯ cargo test
   Compiling passage-id v0.1.3 (/Users/dave/projects/passage-rust)
    Finished test [unoptimized + debuginfo] target(s) in 0.28s
     Running unittests src/lib.rs (target/debug/deps/passage_id-55df813f319fbd43)

running 11 tests
test tests::init_passage ... ok
test tests::reject_bad_kid ... ok
test tests::reject_missing_sub ... ok
test tests::reject_missing_iss ... ok
test tests::reject_missing_exp ... ok
test tests::reject_bad_signature ... ok
test tests::authenticate_good_token ... ok
test tests::reject_missing_nbf ... ok
test tests::reject_future_nbf ... ok
test tests::reject_past_exp ... ok
test tests::reject_wrong_iss ... ok

test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests passage-id

running 2 tests
test src/lib.rs - Passage::new (line 54) ... ok
test src/lib.rs - Passage::authenticate_token (line 85) ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.28s
```